### PR TITLE
Issue #12167 - Fixed persisting zplsc-b cabled data in Cassandra

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Version 0.6.7
 
+* Issue #12167 - Fixed ZPLSC-B cabled data processing in the playback tool
+   * Added a flag to indicate the ZPLSC-B driver has completed the processing of a raw data file.
+   * Used above flag to break out of a infonite loop calling publish.
+   * Added a 1 second delay in the publishing loop, to allow the ZPLSC-B driver to process.
+
 * Issue #13568 - Added capability of processing a 1-hour data file
    * Added option --file - Generate an echogram from a single 1-hour file from the command line
    * Added option --all - Generate all echograms for all ZPLSC instruments

--- a/mi/common/zpls_plot.py
+++ b/mi/common/zpls_plot.py
@@ -131,10 +131,11 @@ class ZPLSPlot(object):
         return min_db, max_db
 
     @staticmethod
-    def _transpose_and_flip(power_dict):
-        for channel in power_dict:
+    def _transpose_and_flip(original_power_dict):
+        power_dict = {}
+        for channel in original_power_dict:
             # Transpose array data so we have time on the x-axis and depth on the y-axis
-            power_dict[channel] = power_dict[channel].transpose()
+            power_dict[channel] = original_power_dict[channel].transpose()
             # reverse the Y axis (so depth is measured from the surface (at the top) to the ZPLS (at the bottom)
             power_dict[channel] = power_dict[channel][::-1]
         return power_dict

--- a/mi/core/instrument/publisher.py
+++ b/mi/core/instrument/publisher.py
@@ -70,6 +70,9 @@ class Publisher(object):
     def set_source(self, source):
         self._headers[self.SOURCE] = source
 
+    def get_max_events(self):
+        return self._max_events
+
     def start(self):
         t = Thread(target=self._run)
         t.setDaemon(True)
@@ -208,6 +211,7 @@ class CountPublisher(Publisher):
         count = len(events)
         self.total += count
         log.info('Publish %d events (%d total)', count, self.total)
+
 
 class IngestEnginePublisher(Publisher):
     """ Publisher used to send particle data to Ingest Engine via a ParticleDataHandler """

--- a/mi/dataset/dataset_driver.py
+++ b/mi/dataset/dataset_driver.py
@@ -22,6 +22,12 @@ class ParticleDataHandler(object):
         log.debug("Particle data capture failed")
         self._failure = True
 
+    def is_particle_data_capture_failure(self):
+        return self._failure
+
+    def get_particle_samples(self):
+        return self._samples
+
 
 class DataSetDriver(object):
     """

--- a/mi/dataset/parser/zplsc_c.py
+++ b/mi/dataset/parser/zplsc_c.py
@@ -131,7 +131,7 @@ class AzfpProfileHeader(BigEndianStructure):
         ('hour', c_ushort),                 # 018 - Hour
         ('minute', c_ushort),               # 020 - Minute
         ('second', c_ushort),               # 022 - Second
-        ('hundredths', c_ushort),           # 024 - Hundreths of a second
+        ('hundredths', c_ushort),           # 024 - Hundredths of a second
         ('digitization_rate', c_ushort*4),  # 026 - Digitization Rate (channels 1-4) (64000, 40000 or 20000)
         ('lockout_index', c_ushort*4),      # 034 - The sample number of samples skipped at start of ping (channels 1-4)
         ('num_bins', c_ushort*4),           # 042 - Number of bins (channels 1-4)


### PR DESCRIPTION
Fixed several issues that now persists zplsc-b cabled data to the Cassandra database.  It now allows the user to use the playback tool or ingest handler to ingest zplsc-b cabled data.
Fixed:
    - Added flag to indicate process completion, set by the driver and monitored by the playback tool.
    - Fixed transpose method in zplsc_plot to operate on a copy, so data passed to the driver is correct.
    - Fixed ingest handler to call zplsc_playback() in playback for zplsc-b data, versus playback()
    - Added logging
    - Added try/catch where needed
ZPLSC-B data can now be persisted to the zplsc_echgram_data table in Cassandra with errors and the offline zplsc echogram is still being generated properly. However, the data is not able to be potted on the UI and there are Edex warnings when ingesting from the ParticleProcessor:
WARN  2018-10-01 05:03:47,478 [Ingest.instrument_particles-2] ingest: PERF: ParticleProcessor - Message [sensor=CE04OSPS-PC01B-05-ZPLSCB102 module=mi.instrument.kut.ek60.ooicore.driver method=streamed source=/home/asadev/rene/raw-data/rsn_cabled/rsn_data/DVT_Data/pc01b/ZPLSCB102_10.33.10.143/OOI-D20170101-T000000.raw] size threshold exceeded [33620760]
There still needs to be investigation of the message size and not being able to plot on the UI.