### PR TITLE
Issue #14149 - Do not discard a perfectly good line at the end of the data burst

### DIFF
--- a/mi/dataset/parser/adcpt_acfgm_dcl_pd8.py
+++ b/mi/dataset/parser/adcpt_acfgm_dcl_pd8.py
@@ -230,9 +230,12 @@ class AdcptAcfgmPd8Parser(SimpleParser):
         this method self._record_buffer will be filled with all the particles in the file.
         """
 
+        nextline = None
         while True:  # loop through file looking for beginning of an adcp data burst
 
-            line = self._stream_handle.readline()  # READ NEXT LINE
+            # READ NEXT LINE, unless we had one buffered
+            line = nextline if nextline else self._stream_handle.readline()
+            nextline = None
 
             if line == "":
                 break
@@ -310,6 +313,7 @@ class AdcptAcfgmPd8Parser(SimpleParser):
                     # Collect velocity data sextets and echo power quartets
                     sensor_data_list.append(line_match.groups()[SENSOR_DATA_BIN:])
                 else:
+                    nextline = line  # pass this line back to the outer loop
                     try:
                         # Transpose velocity data sextets and echo power quartets
                         np_array = numpy.array(sensor_data_list)


### PR DESCRIPTION
Fixes #66.

While parsing a data burst, the inner loop consumes a line at a time and tests
if it matches the sensor data format. If it does not, the data burst is over,
so the new particle is emitted, and the function jumps back to the top o the
outer loop to start looking for the next data burst.

However, that line has now been consumed and cannot be read again by the outer
loop. If the discarded line is the header of the next data burst, parsing will
fail.

This commit fixes that by passing the line back to the outer loop.